### PR TITLE
Let users use misspelled flags.

### DIFF
--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -31,3 +31,4 @@ OTHER DEALINGS IN THE SOFTWARE.
 * @mwilbz for making a great issue and patch
 * @itsnagaraj for making a great issue, providing a lot of thought and code, and being very patient with development of the project
 * @killerwhile for jumping in and making some really neat additions
+* @duongnt for being very patient and checking the spelling in the code and in the docs

--- a/samlauthenticator/samlauthenticator.py
+++ b/samlauthenticator/samlauthenticator.py
@@ -746,7 +746,13 @@ class SAMLAuthenticator(Authenticator):
                 if logout_handler_self.current_user:
                     logout_handler_self._backend_logout_cleanup(logout_handler_self.current_user.name)
 
-                if authenticator_self.slo_forward_on_logout:
+                # This is a little janky, but there was a misspelling in a prior version
+                # where someone could have set the wrong flag because of the documentation.
+                # We will honor the misspelling until we rev the version, and then we will
+                # break backward compatibility.
+                forward_on_logout = True if authenticator_self.slo_forward_on_logout else False
+                forwad_on_logout = True if authenticator_self.slo_forwad_on_logout else False
+                if forward_on_logout or forwad_on_logout:
                     authenticator_self._get_redirect_from_metadata_and_redirect('md:SingleLogoutService',
                                                                                 logout_handler_self)
                 else:


### PR DESCRIPTION
There were some... unfortunate... spellings in the initial
versions of this code. This PR should let users continue to
use the misspellings for a short while (until we bump the
major version) and integrate with @duongnt's fixes.

```
Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 660 York Street, Suite 102, San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
```

Signed-off-by: Tom Kelley <distortedsignal@gmail.com>